### PR TITLE
Fix order by waktu keluar  di resume rawat inap.

### DIFF
--- a/src/rekammedis/RMDataResumePasienRanap.form
+++ b/src/rekammedis/RMDataResumePasienRanap.form
@@ -375,7 +375,7 @@
                     </Property>
                     <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
                       <StringArray count="1">
-                        <StringItem index="0" value="25-07-2023"/>
+                        <StringItem index="0" value="10-11-2023"/>
                       </StringArray>
                     </Property>
                     <Property name="displayFormat" type="java.lang.String" value="dd-MM-yyyy"/>
@@ -403,7 +403,7 @@
                     </Property>
                     <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
                       <StringArray count="1">
-                        <StringItem index="0" value="25-07-2023"/>
+                        <StringItem index="0" value="10-11-2023"/>
                       </StringArray>
                     </Property>
                     <Property name="displayFormat" type="java.lang.String" value="dd-MM-yyyy"/>
@@ -1974,7 +1974,7 @@
                         </Property>
                         <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
                           <StringArray count="1">
-                            <StringItem index="0" value="25-07-2023 10:57:31"/>
+                            <StringItem index="0" value="10-11-2023 12:55:52"/>
                           </StringArray>
                         </Property>
                         <Property name="displayFormat" type="java.lang.String" value="dd-MM-yyyy HH:mm:ss"/>

--- a/src/rekammedis/RMDataResumePasienRanap.java
+++ b/src/rekammedis/RMDataResumePasienRanap.java
@@ -2938,7 +2938,7 @@ public final class RMDataResumePasienRanap extends javax.swing.JDialog {
                     "inner join kamar_inap on kamar_inap.no_rawat=reg_periksa.no_rawat "+
                     "inner join kamar on kamar_inap.kd_kamar=kamar.kd_kamar "+
                     "inner join bangsal on kamar.kd_bangsal=bangsal.kd_bangsal "+
-                    "where reg_periksa.no_rawat=? order by kamar_inap.tgl_keluar desc,kamar_inap.jam_keluar desc limit 1");
+                    "where reg_periksa.no_rawat=? order by cast(concat(kamar_inap.tgl_masuk, ' ', kamar_inap.jam_masuk) as datetime) desc, cast(concat(if (kamar_inap.tgl_keluar = '0000-00-00', current_date(), kamar_inap.tgl_keluar), ' ', if (kamar_inap.jam_keluar = '00:00:00', current_time(), kamar_inap.jam_keluar)) as datetime) desc limit 1");
             try {
                 ps.setString(1,TNoRw.getText());
                 rs=ps.executeQuery();


### PR DESCRIPTION
Closes #63, PR ini memperbaiki bug order by tgl. keluar yang digunakan untuk mengambil waktu keluar dan kamar terakhir pasien dengan menjadikan tgl. dan jam keluar menjadi `datetime`