### PR TITLE
[BP] Fix False Error Template Resep

### DIFF
--- a/src/inventory/DlgPeresepanDokter.form
+++ b/src/inventory/DlgPeresepanDokter.form
@@ -521,7 +521,7 @@
                 </Property>
                 <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
                   <StringArray count="1">
-                    <StringItem index="0" value="22-11-2023"/>
+                    <StringItem index="0" value="26-02-2024"/>
                   </StringArray>
                 </Property>
                 <Property name="displayFormat" type="java.lang.String" value="dd-MM-yyyy"/>

--- a/src/inventory/DlgPeresepanDokter.java
+++ b/src/inventory/DlgPeresepanDokter.java
@@ -2457,6 +2457,8 @@ private void ppBersihkanActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
     public void tampilkanTemplateObat(String namaTemplate) {
         String noResep = Sequel.cariIsi("select no_resep from resep_obat where nama_template = ?", namaTemplate);
         String hargaKelas = "ralan";
+        boolean templateUmumKosong = false,
+                templateRacikanKosong = false;
 
         switch (Jeniskelas.getSelectedItem().toString().toLowerCase()) {
             case "karyawan":
@@ -2536,7 +2538,7 @@ private void ppBersihkanActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
                     rsobat = psresepasuransi.executeQuery();
                     
                     if (! rsobat.first()) {
-                        JOptionPane.showMessageDialog(rootPane, "Maaf, semua stok obat pada template yang dipilih tidak mencukupi..!!");
+                        templateUmumKosong = true;
                     } else {
                         rsobat.beforeFirst();
                     }
@@ -2624,8 +2626,8 @@ private void ppBersihkanActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
                     
                     rsobat = psresep.executeQuery();
                     
-                    if (! rsobat.first()) {
-                        JOptionPane.showMessageDialog(rootPane, "Maaf, semua stok obat pada template yang dipilih tidak mencukupi..!!");
+                    if (! rsobat.first() && STOKKOSONGRESEP.equals("no")) {
+                        templateUmumKosong = true;
                     } else {
                         rsobat.beforeFirst();
                     }
@@ -2757,7 +2759,7 @@ private void ppBersihkanActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
                             rs2 = ps2.executeQuery();
                             
                             if (! rs2.first()) {
-                                JOptionPane.showMessageDialog(rootPane, "Maaf, semua stok obat pada template yang dipilih tidak mencukupi..!!");
+                                templateRacikanKosong = true;
                             } else {
                                 rs2.beforeFirst();
                             }
@@ -2847,7 +2849,7 @@ private void ppBersihkanActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
                             rs2 = ps2.executeQuery();
                             
                             if (! rs2.first()) {
-                                JOptionPane.showMessageDialog(rootPane, "Maaf, semua stok obat pada template yang dipilih tidak mencukupi..!!");
+                                templateRacikanKosong = true;
                             } else {
                                 rs2.beforeFirst();
                             }
@@ -2944,6 +2946,10 @@ private void ppBersihkanActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
                 if (psresep != null) {
                     psresep.close();
                 }
+            }
+            
+            if (templateUmumKosong && templateRacikanKosong) {
+                JOptionPane.showMessageDialog(rootPane, "Maaf, semua stok obat pada template yang dipilih tidak mencukupi..!!");
             }
             
             hitungResep();

--- a/src/inventory/DlgPeresepanDokter.java
+++ b/src/inventory/DlgPeresepanDokter.java
@@ -2626,7 +2626,7 @@ private void ppBersihkanActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
                     
                     rsobat = psresep.executeQuery();
                     
-                    if (! rsobat.first() && STOKKOSONGRESEP.equals("no")) {
+                    if (! rsobat.first()) {
                         templateUmumKosong = true;
                     } else {
                         rsobat.beforeFirst();


### PR DESCRIPTION
PR ini memperbaiki false error yang sering muncul ketika template resep dipilih. Apabila dokter hanya membuat template resep untuk salah satu jenis obat saja (umum / racikan), maka error obat kosong akan muncul.