### PR TITLE
Fix Selisih Debet dan Kredit di Proses Simpan Jurnal

### DIFF
--- a/src/fungsi/sekuel.java
+++ b/src/fungsi/sekuel.java
@@ -2612,7 +2612,20 @@ public final class sekuel {
             
     }
     
-    private void SimpanTrack(String sql){
+    public void simpanTrackerSQL(String sql) {
+        if (AKTIFKANTRACKSQL.equalsIgnoreCase("no")) {
+            return;
+        }
+        try (PreparedStatement ps = connect.prepareStatement("insert into trackersql values (now(), ?, ?)")) {
+            ps.setString(1, sql);
+            ps.setString(2, akses.getkode());
+            ps.executeUpdate();
+        } catch (Exception e) {
+            System.out.println("Notif : " + e);
+        }
+    }
+    
+    private void SimpanTrack(String sql) {
         if(AKTIFKANTRACKSQL.equals("yes")){
             try {
                 ps=connect.prepareStatement("insert into trackersql values(now(),?,?)");

--- a/src/keuangan/Jurnal.java
+++ b/src/keuangan/Jurnal.java
@@ -22,7 +22,7 @@ public class Jurnal {
     private final Connection koneksi = koneksiDB.condb();
     private ResultSet rs, rscek;
     private PreparedStatement ps2, ps, pscek;
-    private String nojur = "";
+    private String nojur = "", track = "";
     private boolean sukses = true;
     
     public boolean simpanJurnalRVPBPJS(String nobukti, String jenis, String keterangan) {
@@ -40,7 +40,8 @@ public class Jurnal {
                             nojur = Sequel.autoNomorSmc("JR", "jurnal", "no_jurnal", 6, "0", rscek.getString("tanggal"));
                             try {
                                 sukses = true;
-                                ps = koneksi.prepareStatement("insert into jurnal values(?,?,?,?,?,?)");
+                                ps = koneksi.prepareStatement("insert into jurnal values (?, ?, ?, ?, ?, ?)");
+                                track = "insert into jurnal values ('" + nojur + "', '" + nobukti + "', '" + rscek.getString("tanggal") + "', '" + rscek.getString("jam") + "', '" + jenis + "', '" + keterangan + "')";
                                 try {
                                     ps.setString(1, nojur);
                                     ps.setString(2, nobukti);
@@ -61,6 +62,7 @@ public class Jurnal {
                                     sukses = true;
                                     nojur = Sequel.autoNomorSmc("JR", "jurnal", "no_jurnal", 6, "0", rscek.getString("tanggal"));
                                     ps = koneksi.prepareStatement("insert into jurnal values(?, ?, ?, ?, ?, ?)");
+                                    track = "insert into jurnal values ('" + nojur + "', '" + nobukti + "', '" + rscek.getString("tanggal") + "', '" + rscek.getString("jam") + "', '" + jenis + "', '" + keterangan + "')";
                                     try {
                                         ps.setString(1, nojur);
                                         ps.setString(2, nobukti);
@@ -79,14 +81,17 @@ public class Jurnal {
                                     }
                                 }
                                 if (sukses == true) {
+                                    Sequel.simpanTrackerSQL(track);
                                     try (ResultSet rsdetail = koneksi.prepareStatement("select * from tampjurnal_rvpbpjs").executeQuery()) {
                                         while (rsdetail.next()) {
                                             try (PreparedStatement psinsert = koneksi.prepareStatement("insert into detailjurnal values (?, ?, ?, ?)")) {
+                                                track = "insert into detailjurnal values ('" + nojur + "', '" + rsdetail.getString(1) + "', " + rsdetail.getString(3) + ", " + rsdetail.getString(4) + ")";
                                                 psinsert.setString(1, nojur);
                                                 psinsert.setString(2, rsdetail.getString(1));
                                                 psinsert.setString(3, rsdetail.getString(3));
                                                 psinsert.setString(4, rsdetail.getString(4));
                                                 psinsert.executeUpdate();
+                                                Sequel.simpanTrackerSQL(track);
                                             } catch (Exception e) {
                                                 sukses = false;
                                                 System.out.println("Notif : " + e);
@@ -142,6 +147,7 @@ public class Jurnal {
                         if (rscek.getInt("selisih") == 0) {
                             nojur = Sequel.autoNomorSmc("JR", "jurnal", "no_jurnal", 6, "0", rscek.getString("tanggal"));
                             try {
+                                track = "insert into jurnal values ('" + nojur + "', '" + nobukti + "', '" + rscek.getString("tanggal") + "', '" + rscek.getString("jam") + "', '" + jenis + "', '" + keterangan + "')";
                                 sukses = true;
                                 ps = koneksi.prepareStatement("insert into jurnal values(?, ?, ?, ?, ?, ?)");
                                 try {
@@ -163,6 +169,7 @@ public class Jurnal {
 
                                 if (sukses == false) {
                                     sukses = true;
+                                    track = "insert into jurnal values ('" + nojur + "', '" + nobukti + "', '" + rscek.getString("tanggal") + "', '" + rscek.getString("jam") + "', '" + jenis + "', '" + keterangan + "')";
                                     nojur = Sequel.autoNomorSmc("JR", "jurnal", "no_jurnal", 6, "0", rscek.getString("tanggal"));
                                     ps = koneksi.prepareStatement("insert into jurnal values(?, ?, ?, ?, ?, ?)");
                                     try {
@@ -184,17 +191,20 @@ public class Jurnal {
                                 }
 
                                 if (sukses == true) {
+                                    Sequel.simpanTrackerSQL(track);
                                     try (PreparedStatement psdetail = koneksi.prepareStatement("select * from tampjurnal_smc where user_id = ? and ip = ?")) {
                                         psdetail.setString(1, akses.getkode());
                                         psdetail.setString(2, akses.getalamatip());
                                         try (ResultSet rsdetail = psdetail.executeQuery()) {
                                             while (rsdetail.next()) {
                                                 try (PreparedStatement psinsert = koneksi.prepareStatement("insert into detailjurnal values (?, ?, ?, ?)")) {
+                                                    track = "insert into detailjurnal values ('" + nojur + "', '" + rsdetail.getString(1) + "', " + rsdetail.getString(3) + ", " + rsdetail.getString(4) + ")";
                                                     psinsert.setString(1, nojur);
                                                     psinsert.setString(2, rsdetail.getString(1));
                                                     psinsert.setString(3, rsdetail.getString(3));
                                                     psinsert.setString(4, rsdetail.getString(4));
                                                     psinsert.executeUpdate();
+                                                    Sequel.simpanTrackerSQL(track);
                                                 } catch (Exception e) {
                                                     sukses = false;
                                                     System.out.println("Notif : " + e);


### PR DESCRIPTION
PR ini (mencoba) memperbaiki pengecekan selisih debet-kredit transaksi jurnal. Sebelumnya, pengecekan menggunakan `BigDecimal` yang kemungkinan bisa mendapat nilai `null` dan bisa tersimpan dengan nilai tersebut. (Resubmisi #133)