### PR TITLE
Fix Kondisi DPJP kedua di Resume Ranap

### DIFF
--- a/src/rekammedis/RMDataResumePasienRanap.java
+++ b/src/rekammedis/RMDataResumePasienRanap.java
@@ -2291,7 +2291,7 @@ public final class RMDataResumePasienRanap extends javax.swing.JDialog {
                 ps=koneksi.prepareStatement("select dpjp_ranap.kd_dokter,dokter.nm_dokter from dpjp_ranap inner join dokter on dpjp_ranap.kd_dokter=dokter.kd_dokter where dpjp_ranap.no_rawat=? and dpjp_ranap.kd_dokter<>?");
                 try {
                     ps.setString(1,tbObat.getValueAt(tbObat.getSelectedRow(),0).toString());
-                    ps.setString(2,tbObat.getValueAt(tbObat.getSelectedRow(),5).toString());
+                    ps.setString(2,tbObat.getValueAt(tbObat.getSelectedRow(),3).toString());
                     rs=ps.executeQuery();
                     i=2;
                     while(rs.next()){


### PR DESCRIPTION
PR ini memperbaiki kondisi pencarian DPJP non-utama untuk menggunakan nama DPJP utama sebagai pemandu pencarian dokter, dimana kolom yang digunakan untuk pencarian nama DPJP non-utama sebelumnya menggunakan nama dokter dari asal poli (Dokter pengirim di resume).