### PR TITLE
Hindari Silent Error di Riwayat Obat & BHP

### DIFF
--- a/src/inventory/DlgCariPermintaan.java
+++ b/src/inventory/DlgCariPermintaan.java
@@ -1086,8 +1086,17 @@ private void ppHapusActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST
         if(tbDokter.getValueAt(tbDokter.getSelectedRow(),0).toString().trim().equals("")){
             Valid.textKosong(TCari,"pilihan data");
         }else{
-            Sequel.queryu("update permintaan_medis set status='Tidak Disetujui' where no_permintaan=?",tbDokter.getValueAt(tbDokter.getSelectedRow(),1).toString().trim());
-            tampil();
+            if (Sequel.cariBooleanSmc("select * from permintaan_medis where permintaan_medis.no_permintaan = ? and permintaan_medis.status = 'Disetujui'", tbDokter.getValueAt(tbDokter.getSelectedRow(), 1).toString().trim())) {
+                if (akses.getadmin()) {
+                    Sequel.queryu("update permintaan_medis set status='Tidak Disetujui' where no_permintaan=?",tbDokter.getValueAt(tbDokter.getSelectedRow(),1).toString().trim());
+                    tampil();
+                } else {
+                    JOptionPane.showMessageDialog(null, "Data permintaan sudah divalidasi...!!");
+                }
+            } else {
+                Sequel.queryu("update permintaan_medis set status='Tidak Disetujui' where no_permintaan=?",tbDokter.getValueAt(tbDokter.getSelectedRow(),1).toString().trim());
+                tampil();
+            }
         } 
     }//GEN-LAST:event_ppTidakDisetujuiActionPerformed
 

--- a/src/inventory/DlgPengeluaranApotek.java
+++ b/src/inventory/DlgPengeluaranApotek.java
@@ -1321,7 +1321,7 @@ private void BtnGudangActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIR
                 if(rs.next()){  
                     kdgudang.setText(rs.getString("kd_bangsaltujuan"));
                     nmgudang.setText(rs.getString("tujuan"));
-                    catatan.setText("No.Permintaan "+rs.getString("no_permintaan")+" Tgl "+rs.getString("tanggal")+" Ruang "+rs.getString("asal")+" oleh "+rs.getString("nama"));
+                    catatan.setText("No.Permintaan "+rs.getString("no_permintaan")+" Tgl. "+rs.getString("tanggal")+ " dari " + rs.getString("kd_bangsal") +" oleh "+rs.getString("nip"));
                 } 
             } catch (Exception e) {
                 System.out.println("Note : "+e);


### PR DESCRIPTION
PR ini mengatur catatan/keterangan pada stok keluar medis untuk menggunakan catatan yang lebih ringkas agar terhindar dari silent error di pencatatan riwayat obat & BHP, yang menyebabkan riwayat obat menjadi tidak sesuai.