### PR TITLE
Fix Jurnal Double pada saat Mengubah Tindakan Pemeriksaan Lab

### DIFF
--- a/src/simrskhanza/DlgUbahPeriksaLab.java
+++ b/src/simrskhanza/DlgUbahPeriksaLab.java
@@ -901,7 +901,7 @@ public final class DlgUbahPeriksaLab extends javax.swing.JDialog {
                             sukses=jur.simpanJurnal(TNoRw.getText(),"U","PEMBATALAN PEMERIKSAAN LABORAT RAWAT JALAN PASIEN OLEH "+akses.getkode());  
                         }
                     }
-                    
+                    ttljmdokter=0;ttljmpetugas=0;ttlkso=0;ttlpendapatan=0;ttlbhp=0;ttljasasarana=0;ttljmperujuk=0;ttlmenejemen=0;
                     if(sukses==true){
                         for(i=0;i<tbTarif.getRowCount();i++){ 
                             if(tbTarif.getValueAt(i,0).toString().equals("true")){


### PR DESCRIPTION
PR ini memperbaiki proses jurnal yang terbentuk nominalnya menjadi double pada saat mengubah tindakan pemeriksaan lab.

Hal ini terjadi karena pada saat mengubah tindakan pemeriksaan lab akan membuat dua jurnal, yaitu jurnal pembatalan dan jurnal transaksi baru untuk tindakan yang diubah.

Setelah jurnal pembatalan, nominal untuk detail jurnal tidak terreset menjadi 0 yang menyebabkan detail transaksi di jurnal baru mengikuti nominal dari detail jurnal sebelumnya.