### PR TITLE
Deteksi booking MobileJKN dibatalkan di APM

### DIFF
--- a/anjunganpasienmandiri/src/khanzahmsanjungan/DlgCekDataBPJS.java
+++ b/anjunganpasienmandiri/src/khanzahmsanjungan/DlgCekDataBPJS.java
@@ -312,6 +312,8 @@ public class DlgCekDataBPJS extends widget.Dialog {
                         regist.setVisible(true);
                         flag = -1;
                         dispose();
+                    } else if (Sequel.cariExistsSmc("select * from referensi_mobilejkn_bpjs where nomorkartu = ? and tanggalperiksa = current_date() and status in ('Batal', 'Gagal')", noKartu)) {
+                        Valid.popupPeringatanDialog("Booking MobileJKN Anda telah dibatalkan.\nSilahkan konfirmasi ke bagian Pendaftaran.", 7);
                     } else {
                         Valid.popupGagalDialog("Data booking MobileJKN tidak ditemukan..!!", 5);
                     }


### PR DESCRIPTION
## Summary

- Adds a secondary check in the APM kiosk's `cek()` method to detect cancelled/failed MobileJKN bookings (`status in ('Batal', 'Gagal')`) before falling through to the generic "not found" error
- Shows an actionable warning dialog directing the patient to the registration desk: *"Booking MobileJKN Anda telah dibatalkan. Silahkan konfirmasi ke bagian Pendaftaran."*
- Uses `popupPeringatanDialog` (warning/yellow) with a 7-second timeout for readability

Closes #370

## Test plan

- [ ] Active booking (`status='Belum'`) → should proceed to check-in normally
- [ ] Cancelled booking (`status='Batal'`) → should show warning with "dibatalkan" message
- [ ] Failed booking (`status='Gagal'`) → should show warning with "dibatalkan" message
- [ ] No booking at all → should show "tidak ditemukan" error
- [ ] Already checked in (`status='Checkin'`) → should proceed normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)