### PR TITLE
Pembaruan harga IPSRS berdasarkan harga neto per satuan (Plan A)

### DIFF
--- a/sik_modif.sql
+++ b/sik_modif.sql
@@ -2017,3 +2017,16 @@ ALTER TABLE `user` MODIFY COLUMN IF EXISTS `satu_sehat_kirim_clinicalimpression`
 ALTER TABLE `user` MODIFY COLUMN IF EXISTS `template_persetujuan_penolakan_tindakan` enum('true','false') NULL DEFAULT NULL AFTER `laporan_anestesi`;
 
 SET FOREIGN_KEY_CHECKS=1;
+CREATE TABLE IF NOT EXISTS `riwayat_harga_ipsrs` (
+    `id`         INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `kode_brng`  VARCHAR(20) NOT NULL,
+    `harga_lama` DOUBLE NOT NULL DEFAULT 0,
+    `harga_baru` DOUBLE NOT NULL DEFAULT 0,
+    `no_faktur`  VARCHAR(20) NOT NULL,
+    `jenis`      ENUM('pemesanan','pembelian') NOT NULL,
+    `tgl`        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `nip`        VARCHAR(20) NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `kode_brng` (`kode_brng`),
+    KEY `no_faktur` (`no_faktur`)
+) ENGINE=InnoDB;

--- a/src/ipsrs/IPSRSPembelian.java
+++ b/src/ipsrs/IPSRSPembelian.java
@@ -682,8 +682,13 @@ private void KdKeyPressed(java.awt.event.KeyEvent evt) {//GEN-FIRST:event_TKdKey
                                     tbDokter.getValueAt(i,0).toString(),tbDokter.getValueAt(i,1).toString()
                                 });
                                 if(tbDokter.getValueAt(i,4).toString().equals("true")&&(akses.getipsrs_barang()==true)){
+                                    String hargaBaru=(Double.parseDouble(tbDokter.getValueAt(i,9).toString())/Double.parseDouble(tbDokter.getValueAt(i,0).toString()))+"";
+                                    String hargaLama=Sequel.cariIsi("SELECT harga FROM ipsrsbarang WHERE kode_brng='"+tbDokter.getValueAt(i,1).toString()+"'");
+                                    if(hargaLama==null) hargaLama="0";
+                                    Sequel.menyimpantfSmc("riwayat_harga_ipsrs","kode_brng,harga_lama,harga_baru,no_faktur,jenis,nip",
+                                        tbDokter.getValueAt(i,1).toString(),hargaLama,hargaBaru,NoFaktur.getText(),"pembelian",akses.getkode());
                                     Sequel.mengedit("ipsrsbarang","kode_brng=?","harga=?",2,new String[]{
-                                        (Double.parseDouble(tbDokter.getValueAt(i,5).toString())+((Double.parseDouble(tppn.getText())/100)*Double.parseDouble(tbDokter.getValueAt(i,5).toString())))+"",tbDokter.getValueAt(i,1).toString()
+                                        hargaBaru,tbDokter.getValueAt(i,1).toString()
                                     });
                                 }
                             }else{

--- a/src/ipsrs/IPSRSPemesanan.java
+++ b/src/ipsrs/IPSRSPemesanan.java
@@ -729,8 +729,13 @@ private void KdKeyPressed(java.awt.event.KeyEvent evt) {//GEN-FIRST:event_TKdKey
                                     tbDokter.getValueAt(i,0).toString(),tbDokter.getValueAt(i,1).toString()
                                 });
                                 if(tbDokter.getValueAt(i,4).toString().equals("true")&&(akses.getipsrs_barang()==true)){
+                                    String hargaBaru=(Double.parseDouble(tbDokter.getValueAt(i,9).toString())/Double.parseDouble(tbDokter.getValueAt(i,0).toString()))+"";
+                                    String hargaLama=Sequel.cariIsi("SELECT harga FROM ipsrsbarang WHERE kode_brng='"+tbDokter.getValueAt(i,1).toString()+"'");
+                                    if(hargaLama==null) hargaLama="0";
+                                    Sequel.menyimpantfSmc("riwayat_harga_ipsrs","kode_brng,harga_lama,harga_baru,no_faktur,jenis,nip",
+                                        tbDokter.getValueAt(i,1).toString(),hargaLama,hargaBaru,NoFaktur.getText(),"pemesanan",akses.getkode());
                                     Sequel.mengedit("ipsrsbarang","kode_brng=?","harga=?",2,new String[]{
-                                        (Double.parseDouble(tbDokter.getValueAt(i,5).toString())+((Double.parseDouble(tppn.getText())/100)*Double.parseDouble(tbDokter.getValueAt(i,5).toString())))+"",tbDokter.getValueAt(i,1).toString()
+                                        hargaBaru,tbDokter.getValueAt(i,1).toString()
                                     });
                                 }
                             }else{


### PR DESCRIPTION
## Summary

Fixes the price update formula in `IPSRSPemesanan` and `IPSRSPembelian` to use the actual net discounted unit cost instead of catalog price plus VAT. Also adds a price change history log table.

- **Price formula change**: `harga_baru = jmltotal / jumlah` (net unit cost after discount) — replaces the previous `catalog_price × (1 + PPN%)` which double-counted VAT already recorded as PPN Masukan and ignored the purchase discount
- **History logging**: Before overwriting `ipsrsbarang.harga`, the old and new values are recorded to the new `riwayat_harga_ipsrs` table along with the originating transaction (`no_faktur`, `jenis`, `nip`)
- **Journal**: Unchanged — Persediaan continues to be debited at net-after-discount total (`ttl`)

## Accounting effect

| | Before | After |
|---|---|---|
| `ipsrsbarang.harga` set to | catalog × 1.11 | `jmltotal / jumlah` (net unit cost) |
| Dispensary outflow (7 of 10 items @ 1,425,000) | 14,763,000 | 9,975,000 |
| Persediaan balance after outflow | −513,000 (negative) | 4,275,000 ✓ |

## Migration

Run `sik_modif.sql` to create the `riwayat_harga_ipsrs` table before deploying.

## Related

This is Plan A of two options presented to accounting. See also Plan B: #400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)