### PR TITLE
Apply Pengaturan `DEPOAKTIFOBAT` untuk Penerimaan Obat & BHP Farmasi

### DIFF
--- a/src/fungsi/koneksiDB.java
+++ b/src/fungsi/koneksiDB.java
@@ -1383,11 +1383,10 @@ public class koneksiDB {
     public static String DEPOAKTIFOBAT(){
         try (FileInputStream fis = new FileInputStream("setting/database.xml")) {
             prop.loadFromXML(fis);
-            var=prop.getProperty("DEPOAKTIFOBAT", "").trim().replaceAll("'","");
-        }catch(Exception e){
-            var="";
+            return prop.getProperty("DEPOAKTIFOBAT", "").trim().replaceAll("'", "");
+        } catch (Exception e) {
+            return "";
         }
-        return var;
     }
 
     public static String STOKKOSONGRESEP(){

--- a/src/inventory/DlgPemesanan.java
+++ b/src/inventory/DlgPemesanan.java
@@ -64,6 +64,7 @@ public class DlgPemesanan extends javax.swing.JDialog {
     private FileReader myObj;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private volatile boolean ceksukses = false;
+    private final String DEPOAKTIFOBAT = koneksiDB.DEPOAKTIFOBAT();
 
     /** Creates new form DlgProgramStudi
      * @param parent
@@ -1794,6 +1795,11 @@ private void KdKeyPressed(java.awt.event.KeyEvent evt) {//GEN-FIRST:event_TKdKey
             btnPetugas.setEnabled(false);
             kdptg.setText(akses.getkode());
             nmptg.setText(Sequel.CariPetugas(kdptg.getText()));
+        }
+        if (!DEPOAKTIFOBAT.isBlank()) {
+            btnGudang.setEnabled(false);
+            kdgudang.setText(DEPOAKTIFOBAT);
+            nmgudang.setText(Sequel.CariBangsal(DEPOAKTIFOBAT));
         }
     }
 


### PR DESCRIPTION
PR ini bertujuan untuk menggunakan pengaturan `DEPOAKTIFOBAT` pada menu penerimaan Obat & BHP, agar bisa menetapkan penerimaan satu pintu.