### PR TITLE
Fix Ambil Hasil BIOSYS Untuk Pemeriksaan Sebagai Sub Tindakan

### DIFF
--- a/src/bridging/ApiBIOSYS.java
+++ b/src/bridging/ApiBIOSYS.java
@@ -282,6 +282,22 @@ public class ApiBIOSYS {
         }
     }
 
+    public JsonNode ambilOrder(String noorder) throws BiosysException {
+        try {
+            String request = Sequel.cariIsiSmc(
+                "select lis_request_response.request from lis_request_response where lis_request_response.vendor = 'biosys' and lis_request_response.noorder = ? " +
+                "and lis_request_response.method = 'POST' and lis_request_response.url like '%lab_order.php' order by lis_request_response.id desc limit 1", noorder);
+
+            if (request == null || request.isBlank()) {
+                return mapper.createObjectNode();
+            }
+
+            return mapper.readTree(request);
+        } catch (Exception e) {
+            throw new BiosysException("Gagal mengambil order terkirim ke LIS BIOSYS: " + e.getMessage(), e);
+        }
+    }
+
     public JsonNode ambilHasil(String noorder) throws BiosysException {
         try {
             String url = APIURL + "/lab_result.php?OrderNumber=" + noorder;

--- a/src/simrskhanza/DlgPeriksaLaboratorium.java
+++ b/src/simrskhanza/DlgPeriksaLaboratorium.java
@@ -43,8 +43,10 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -3584,10 +3586,38 @@ public final class DlgPeriksaLaboratorium extends javax.swing.JDialog {
 
                 belumFinal = false;
 
+                Map<String, String> iditem = new HashMap<>();
+                biosys.ambilOrder(noorder).path("OrderedItems").forEach(header -> header.withArray("Items").forEach(item -> {
+                    String namaitem = item.path("ItemName").asText("").trim().toUpperCase();
+                    String iditemplate = item.path("ItemCode").asText("").trim();
+                    if (!namaitem.isEmpty() && !iditemplate.isEmpty()) {
+                        iditem.put(namaitem, iditemplate);
+                    }
+                }));
+
+                Set<String> namasub = new HashSet<>();
+                Set<String> namajudul = new HashSet<>();
+                for (JsonNode result : sortedResults) {
+                    namasub.add(result.path("TestNameSub").asText("").trim().toUpperCase());
+                    namajudul.add(result.path("TestNameHeader").asText("").trim().toUpperCase());
+                }
+                namajudul.removeAll(namasub);
+
+                Set<String> idjudul = new HashSet<>();
+                for (String namaheader : namajudul) {
+                    if (iditem.containsKey(namaheader)) {
+                        idjudul.add(iditem.get(namaheader));
+                    }
+                }
+
                 Map<String, Integer> map = new HashMap<>();
                 for (int row = 0; row < tabMode.getRowCount(); row++) {
-                    tabMode.setValueAt(tabMode.getValueAt(row, 1).toString().startsWith("   " + LABORATORIUMSUBHEADERPREFIX), row, 0);
-                    map.put(tabMode.getValueAt(row, 6).toString(), row);
+                    String pemeriksaan = tabMode.getValueAt(row, 1).toString();
+                    String idtemplate = tabMode.getValueAt(row, 6).toString();
+                    boolean judul = (!LABORATORIUMSUBHEADERPREFIX.isEmpty() && pemeriksaan.startsWith("   " + LABORATORIUMSUBHEADERPREFIX))
+                        || idjudul.contains(idtemplate);
+                    tabMode.setValueAt(judul, row, 0);
+                    map.put(idtemplate, row);
                 }
 
                 for (JsonNode result : sortedResults) {


### PR DESCRIPTION
## The bug

In `DlgPeriksaLaboratorium.ambilHasilBIOSYS`, subheader rows that are genuine BIOSYS sub-exams were left unchecked when results arrived, so they never got saved and disappeared from the printout.

Root cause: BIOSYS accepts them on the order but resolves them to its header level and never echoes them back as a TestNameSub. On order `PK202608010129`:

- `46818 DARAH LENGKAP` and `46846 URINE LENGKAP` were sent as items, accepted, and came back only as `TestNameHeader` (191047, 601001) — 17 and 20 items nested beneath them.
- `map.get(idtemplate)` is therefore never reached for them, and the blanket reset at line 3589 leaves them false.
- `46834 --- KIMIA KLINIK` was unaffected because the marker prefix already covers it.

You confirmed the response has looked like this since the service went live, so it isn't a vendor regression.

Final change (uncommitted, `c/fix-biosys-subheader-hasil`, branched from custom)

`src/bridging/ApiBIOSYS.java` — new `ambilOrder(String noorder)` reads back the sent order from `lis_request_response` (method='POST', url like '%lab_order.php', order by id desc limit 1 since the table has no timestamp). Returns an empty
node when nothing is logged.

`src/simrskhanza/DlgPeriksaLaboratorium.java` — heading detection in three steps:

1. `iditem` ← `ItemName` → `ItemCode` from the request's OrderedItems
2. `namajudul` ← `TestNameHeader` − `TestNameSub` from the results
3. `idjudul` ← those names resolved through `iditem` to `id_template`

The row loop checks `idjudul.contains(idtemplate)`, so headings are identified by code, not display text. The "   " [Three spaces] discriminator now only guards the category prefix.

The `TestNameSub` subtraction is load-bearing: `Glukosa Puasa`, `SGOT/AST`, `Ureum` and nine others appear as both header and sub, and without it an unperformed one would be promoted to a heading.

ant compile passes. Simulated against your sample: `idjudul = {46818, 46846};` headings kept `46818` / `46834` / `46846`; 47 rows receive values; unchecked are the panel row, `46839/46840`, and `46859`.

### Rejected along the way

- `TestHis` token-matching (`matches("\\d+")` → `map::containsKey`) — my first hypothesis, disproved by your data: all 49 TestHis values are clean `id_templates` and both rules resolve identically. Reverted.
- Keeping empty-name rows (`46839/46840`, the LDL range continuation lines) — you ruled it out; ReferenceRange/NormalRange now supersedes `nilai_rujukan`, and keeping them breaks the later edit in DlgUbahNilaiLab. Reverted.
- Collision workaround for TestHis: "46856,46859" — you ruled it out as bad BIOSYS mapping data that shouldn't be masked. Reverted; `46859 Lekosit` stays unchecked and visible.
- `LABORATORIUMSUBHEADERITEMPREFIX` setting — built, then dropped when you asked whether it could be derived instead. `database.xml.example` and `koneksiDB.java` are back at baseline.
- Request-minus-response — would yield `{46818, 46846, 46859}`, silently promoting `Lekosit` to a section title because of that same bad mapping.

### Open for when you can test

1. Missing request log — if the row is purged or predates logging, `idjudul` is empty and subheaders go unchecked exactly as today, silently. A fallback to matching namajudul against the row text is two lines if you want it.
2. New DB read — one extra query per result fetch, parsing ~8 KB from a text column, on a path that previously did none.
3. Naming coupling — `TestNameHeader` must match `template_laboratorium.Pemeriksaan`. Works today (case-insensitively: BIOSYS says Urine Lengkap, the template says URINE LENGKAP); a BIOSYS-side rename reintroduces the bug with no signal.
4. `46856` double-write — Lekosit Esterase is still overwritten by the - Leukosit result before Lekosit is left empty. Left as-is per your call; it's a BIOSYS mapping fix.
5. `DlgUbahNilaiLab` needs no equivalent change (no checkbox column), but it resolves TestHis via `map::containsKey` while this dialog uses `matches("\\d+")`. They agree on current data; untouched.

MCU000794A.json is still untracked in the project root. MCU000794A.xlsx is no longer showing as untracked. A scratch differ for comparing two BIOSYS payloads is at `…\scratchpad\biosysdiff.py` if it's useful later.